### PR TITLE
Finally fix that lingering WS connection

### DIFF
--- a/tinychat.py
+++ b/tinychat.py
@@ -172,7 +172,7 @@ class Client:
         """
         log.info('disconnecting from server')
         if self._ws is not None:
-            self._ws.close()
+            self._ws.close(timeout=0)
 
         self._req = 1
         self._ws = None


### PR DESCRIPTION
From [_core.WebSocket.close()](https://github.com/websocket-client/websocket-client/blob/master/websocket/_core.py#L392):
```py
    def close(self, status=STATUS_NORMAL, reason=six.b(""), timeout=3):
        """
        Close Websocket object
        status: status code to send. see STATUS_XXX.
        reason: the reason to close. This must be string.
        timeout: timeout until receive a close frame.       <<<<<<<
            If None, it will wait forever until receive a close frame.
        """
```
Ideally there won't be any more hunting to kill off that lingering python process.